### PR TITLE
EB-5016 : Add gettext-base to node install dependencies

### DIFF
--- a/edgemanager-install.sh
+++ b/edgemanager-install.sh
@@ -279,7 +279,7 @@ install_node()
 
   export DEBIAN_FRONTEND=noninteractive
   apt-get update -qq
-  apt-get install -y -qq wget ca-certificates curl gnupg lsb-release
+  apt-get install -y -qq wget ca-certificates curl gnupg lsb-release gettext-base
 
   show_progress 5
 


### PR DESCRIPTION
## Summary

Adds `gettext-base` to the node `apt-get install` step in `install_node()`.

`gettext-base` provides the `envsubst` binary on Ubuntu/Debian nodes. This is required by a change in [edgebuilder-controller PR #1915](https://github.com/IOTechSystems/edgebuilder-controller/pull/1915), which moves `${VAR}` substitution in app config files from inside the Alpine configurator container to the node host. Today's code fails to run because the alpine image loaded from disk (installed via our installer) doesn't have gettext/envsubst.  Running `envsubst` on the host (before `docker cp` stages files into Docker volumes) eliminates the dependency on having to bake `gettext` a new alpine base image into the configurator container image, and avoids any network or timeout risk from attempting `apk add` at runtime on potentially air-gapped edge nodes.

`gettext-base` is the minimal Debian/Ubuntu package (~200KB) that provides just `envsubst` and the runtime gettext tools, without the full gettext development toolchain.

## Test plan

- [ ] Run node installer on Ubuntu — verify `envsubst` is available after install (`which envsubst`)
- [ ] Run node installer on Debian — verify `envsubst` is available after install
- [ ] Confirm existing install behaviour is otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)